### PR TITLE
Cart and facebook configure improvements

### DIFF
--- a/theme/accounts/accounts.less
+++ b/theme/accounts/accounts.less
@@ -337,7 +337,7 @@
   font-family: @font-family-base;
 
   z-index: 1001;
-  position: fixed;
+  position: absolute;
 
   left: 50%;
   margin-left: -(@login-buttons-accounts-dialog-width
@@ -370,6 +370,7 @@
   .configuration_inputs { width: 70%; }
   .new-section { margin-top: 10px; }
   .url { font-family: @font-family-serif; }
+  .configure-login-service-dismiss-button { margin-bottom: 0.5em;}
 }
 
 #configure-login-service-dialog-save-configuration {

--- a/theme/cart/cartDrawer/cartItems/cartItems.less
+++ b/theme/cart/cartDrawer/cartItems/cartItems.less
@@ -41,6 +41,7 @@
       height: 225px;
       background-position: center center;
       background-repeat: no-repeat;
+      background-size: cover;
       overflow: hidden;
   }
 

--- a/theme/cart/cartDrawer/cartSubTotals/cartSubTotals.less
+++ b/theme/cart/cartDrawer/cartSubTotals/cartSubTotals.less
@@ -9,4 +9,8 @@
     background-color: @cart-drawer-bg;
     color: contrast(@cart-drawer-bg, black, white);
   }
+  thead {
+    height: 2em;
+    font-weight: 900;
+  }
 }


### PR DESCRIPTION
Added space and weight to 'Your Cart' row.
Now configure facebook login dialog is fully visiable in smaller screen by scrolling.
Added padding for the configure dialog buttons.
Now items in shopping cart are properly scaled.

It seems that .cart-items .center-cropped has its background-image set to item's image, and there's also an img inside the div with its src set to item's image. Is there any reason why they're doing the same thing except <img> is set to 0 opacity.

