### PR TITLE
Small progress steps title style updated

### DIFF
--- a/theme/cart/checkout/progressBar/progressBar.less
+++ b/theme/cart/checkout/progressBar/progressBar.less
@@ -94,7 +94,7 @@
 .progress-step-label {
   position: absolute;
   left: 0;
-  bottom: -20px;
+  top: 55px;
   width: 100%;
 
   text-align: center;


### PR DESCRIPTION
Hi, there were a small bug with styles on a narrow viewport:
![reaction_progress_steps_com](https://cloud.githubusercontent.com/assets/11130487/10576623/36b697f4-767e-11e5-8d91-32f26db3a64f.jpeg)
